### PR TITLE
Re-add dkim record creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ INSTANCE_NAME ?= instance-$(USER)
 CLOUD_PROVISION_PARAMS="{}"
 CLOUD_BIND_PARAMS="{}"
 
-PREREQUISITES = docker jq eden
+PREREQUISITES = docker jq eden checkdmarc
 K := $(foreach prereq,$(PREREQUISITES),$(if $(shell which $(prereq)),some string,$(error "Missing prerequisite commands $(prereq)")))
 
 check:

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,7 @@ up: ## Run the broker service with the brokerpak configured. The broker listens 
 	-d \
 	--rm \
 	$(CSB) serve
-	@while [ "`docker inspect -f {{.State.Health.Status}} csb-service-$(SERVICE_NAME)`" != "healthy" ]; do   echo "Waiting for csb-service to be ready..." ; sleep 2; done
-	@echo "csb-service is ready!" ; echo ""
+	@./bin/docker-wait.sh csb-service-$(SERVICE_NAME)
 	@docker ps -l
 
 down: .env.secrets ## Bring the cloud-service-broker service down

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ building, serving, and testing the brokerpak.
 
 1. `make` is used for executing docker commands in a meaningful build cycle. 
 1. [`eden`](https://github.com/starkandwayne/eden) is used as a client for testing the brokerpak
+1. [`checkdmarc`](https://pypi.org/project/checkdmarc/) is used to verify the DMARC and SPF configuration of configured instances
 1. AWS account credentials (as environment variables) are used for actual
    service provisioning. The corresponding user must have at least the permissions described in `permission-policies.tf`. Set at least these variables:
 

--- a/bin/docker-wait.sh
+++ b/bin/docker-wait.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Simple script to wait for Docker container $1 to become healthy, according to
+# its own health check.
+# Based on https://stackoverflow.com/a/46625302/17138235
+
+set -e
+
+function getContainerHealth {
+	docker inspect --format "{{.State.Health.Status}}" $1
+}
+
+function waitContainer {
+	while STATUS=$(getContainerHealth $1); [[ $STATUS != "healthy" ]]; do 
+		if [[ $STATUS == "unhealthy" ]]; then
+			echo "Failed!"
+			exit -1
+		fi
+		printf .
+		lf=$'\n'
+		sleep 1 # Any less frequent and we might miss the "unhealthy" condition!
+	done
+	printf "$lf"
+}
+
+waitContainer $1
+
+# while true ; do
+# 	docker inspect --format "{{.State.Health.Status}}" csb-service
+# 	sleep 1
+# done

--- a/smtp.yml
+++ b/smtp.yml
@@ -48,7 +48,7 @@ provision:
       type: string
       details: Domain to send mail from
       default: ""
-    - field_name: email_reciept_error
+    - field_name: email_receipt_error
       type: string
       details: Email to recieve DMARC errors
       default: "datagovhelp@gsa.gov"
@@ -81,7 +81,7 @@ provision:
   - field_name: verification_record
     type: object
     details: If a domain was supplied, TXT record to be created
-  - field_name: email_reciept_error
+  - field_name: email_receipt_error
     type: string
     details: Email to recieve DMARC errors
   - field_name: instructions

--- a/terraform/provision/Dockerfile
+++ b/terraform/provision/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.12.31 as terraform
+FROM hashicorp/terraform:0.13.7 as terraform
 
 RUN apk update
 RUN apk add --update git 

--- a/terraform/provision/main.tf
+++ b/terraform/provision/main.tf
@@ -11,7 +11,7 @@ locals {
     name    = "_dmarc.${local.domain}"
     type    = "TXT"
     ttl     = "600"
-    records = ["v=DMARC1; p=quarantine; rua=mailto:${var.email_reciept_error}; ruf=mailto:${var.email_reciept_error}"]
+    records = ["v=DMARC1; p=quarantine; rua=mailto:${var.email_receipt_error}; ruf=mailto:${var.email_receipt_error}"]
   }
   spf_verification_record = {
     name    = local.domain
@@ -84,6 +84,6 @@ resource "null_resource" "dmarc_records" {
     name    = "_dmarc.${local.domain}"
     type    = "TXT"
     ttl     = "600"
-    records = "v=DMARC1; p=quarantine; rua=mailto:${var.email_reciept_error}; ruf=mailto:${var.email_reciept_error}"
+    records = "v=DMARC1; p=quarantine; rua=mailto:${var.email_receipt_error}; ruf=mailto:${var.email_receipt_error}"
   }
 }

--- a/terraform/provision/outputs.tf
+++ b/terraform/provision/outputs.tf
@@ -16,8 +16,8 @@ output dmarc_records {
   value = var.domain != "" ? local.dmarc_records : null
 }
 
-output email_reciept_error {
-    value = var.email_reciept_error
+output email_receipt_error {
+    value = var.email_receipt_error
 }
 
 output instructions {

--- a/terraform/provision/terraform.tfvars-template
+++ b/terraform/provision/terraform.tfvars-template
@@ -1,2 +1,5 @@
-region="us-west-2"    # Region to host SMTP server in
-domain="example.com"  # Custom domain for user to configure on their own
+region              = "us-west-2"               # Region to host SMTP server in
+domain              = ""                        # Custom domain 
+default_domain      = "ssb-dev.data.gov"        # Domain under which to create a domain if none was supplied
+instance_name       = "instance-yourname"       # Avoids collisions with others
+email_receipt_error = "youraddress@yourdomain"  # Address where notification of email recipt errors should be sent

--- a/terraform/provision/variables.tf
+++ b/terraform/provision/variables.tf
@@ -12,14 +12,13 @@ variable "default_domain" {
 
 variable "instance_name" {
   type    = string
-  default = ""
 }
 
-variable region {
+variable "region" {
   type = string
 }
 
-variable email_reciept_error {
+variable "email_receipt_error" {
   type = string
 }
 

--- a/terraform/provision/verification.tf
+++ b/terraform/provision/verification.tf
@@ -40,22 +40,22 @@ resource "aws_route53_record" "records" {
   zone_id = aws_route53_zone.instance_zone[0].zone_id
 }
 
-# Previously, we had to create CNAME records for these DKIM tokens, but now AWS
-# does that automatically when it's managing the same domain in Route53.
-# Leaving the code here for reference.
-#s
-# resource "aws_route53_record" "dkim" {count = 3
+# AWS is supposed to handle the creation of DKIM records to the domain
+# if using Route53; however it does not seem to be applied appropriately.
 
-#   zone_id = aws_route53_zone.instance_zone[0].zone_id
-#   name = format(
-#     "%s._domainkey.%s",
-#     element(aws_ses_domain_dkim.dkim.dkim_tokens, count.index),
-#     local.domain,
-#   )
-#   type    = "CNAME"
-#   ttl     = "600"
-#   records = ["${element(aws_ses_domain_dkim.dkim.dkim_tokens, count.index)}.dkim.amazonses.com"]
-# }
+resource "aws_route53_record" "dkim" {
+  count = (var.domain == "" ? 3 : 0)
+  
+  zone_id = aws_route53_zone.instance_zone[0].zone_id
+  name = format(
+    "%s._domainkey.%s",
+    element(aws_ses_domain_dkim.dkim.dkim_tokens, count.index),
+    local.domain,
+  )
+  type    = "CNAME"
+  ttl     = "600"
+  records = ["${element(aws_ses_domain_dkim.dkim.dkim_tokens, count.index)}.dkim.amazonses.com"]
+}
 
 # Wait on the verification to succeed
 resource "aws_ses_domain_identity_verification" "verification" {

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,6 @@ echo "Is dmarc valid?"
 checkdmarc $domain | jq '.dmarc'
 checkdmarc $domain | jq --exit-status '.dmarc.valid'
 
-# Would use this to test and get if spf record is valid
 echo "Is spf valid?"
 checkdmarc $domain | jq '.spf'
 checkdmarc $domain | jq --exit-status '.spf.valid'


### PR DESCRIPTION
AWS is supposed to be handling this ([see sec 6 here](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim-easy-setup-domain.html)), but we are getting alerts on every test that DKIM verification is failing (3 days after the fact).
This should make the DKIM records manually as noted [in terraform docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_dkim#example-usage).

Related to https://github.com/GSA/datagov-deploy/issues/3511