### PR TITLE
Update versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,9 @@ jobs:
 
     - name: Run examples (tests if a domain IS supplied)
       # wait for the container to come down before we try to bring it back up
-      run: docker wait csb-service-datagov-smtp || make up && make test-supplied && make down
+      run: |
+        docker wait csb-service-datagov-smtp
+        make up && make test-supplied && make down
 
     - name: Clean up if there was a failure
       if: ${{ failure() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,19 +46,17 @@ jobs:
         INSTANCE_NAME="$(echo ci-test1-${{ github.event.pull_request.number }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT})"
         echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
 
-    - name: Run examples (tests if NO domain is supplied)
-      run: make up && make test && make down
+    - name: Bring up the CSB in Docker
+      run: make up
 
-    - name: Set the instance name for subsequent steps (Test 2)
-      run: |
-        INSTANCE_NAME="$(echo ci-test2-${{ github.event.pull_request.number }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT})"
-        echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
+    - name: Run tests if NO domain is supplied
+      run: make test
 
-    - name: Run examples (tests if a domain IS supplied)
-      # wait for the container to come down before we try to bring it back up
-      run: |
-        docker wait csb-service-datagov-smtp
-        make up && make test-supplied && make down
+    - name: Run tests if a domain IS supplied
+      run: make test-supplied 
+
+    - name: Bring down the CSB in Docker
+      run: make down
 
     - name: Clean up if there was a failure
       if: ${{ failure() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   make:
-    name: 'Make'
+    name: 'Make test'
     runs-on: ubuntu-latest
     env:
       # For storing the Terraform state for the deployment
@@ -55,7 +55,8 @@ jobs:
         echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
 
     - name: Run examples (tests if a domain IS supplied)
-      run: make up && make test-supplied && make down
+      # wait for the container to come down before we try to bring it back up
+      run: docker wait csb-service-datagov-smtp || make up && make test-supplied && make down
 
     - name: Clean up if there was a failure
       if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .DEFAULT_GOAL := help
 
 DOCKER_OPTS=--rm -v $(PWD):/brokerpak -w /brokerpak
-CSB=ghcr.io/gsa/cloud-service-broker:v0.10.0gsa
+CSB=ghcr.io/gsa/cloud-service-broker:v2.0.3gsa
 SECURITY_USER_NAME := $(or $(SECURITY_USER_NAME), user)
 SECURITY_USER_PASSWORD := $(or $(SECURITY_USER_PASSWORD), pass)
 

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ demo-up-supplied: ## Provision an SMTP instance and output the bound credentials
 	set -e ;\
 	eval "$$( $(CSB_SET_IDS) )" ;\
 	echo "Provisioning ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}" ;\
-	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                       --params '{ "domain": "test.com", "enable_feedback_notifications": false, "mail_from_subdomain": "mail" }' 2>&1 > ${INSTANCE_NAME}.provisioning.txt ;\
+	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                       --params '{ "domain": "example.com", "enable_feedback_notifications": false, "mail_from_subdomain": "mail" }' 2>&1 > ${INSTANCE_NAME}.provisioning.txt ;\
 	$(CSB_INSTANCE_WAIT) ${INSTANCE_NAME} ;\
 	echo "Binding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding2" ;\
 	$(CSB_EXEC) client bind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding2 --params '{}' | jq -r .response > ${INSTANCE_NAME}.binding.json ;\

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,15 +7,17 @@ platforms:
 - os: linux
   arch: amd64
 terraform_binaries:
-- name: terraform
-  version: 0.13.7
-  source: https://github.com/hashicorp/terraform/archive/v0.13.7.zip
+- name: tofu
+  version: 1.9.0
+  source: https://github.com/opentofu/opentofu/archive/v1.9.0.zip
 - name: terraform-provider-aws
-  version: 3.46.0
-  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v3.46.0.zip
+  version: 5.88.0
+  source: https://releases.hashicorp.com/terraform-provider-aws/5.88.0/terraform-provider-aws_5.88.0_linux_amd64.zip
+  provider: registry.opentofu.org/hashicorp/aws
 - name: terraform-provider-null
-  version: 3.1.0
-  source: https://releases.hashicorp.com/terraform-provider-null/3.1.0/terraform-provider-null_3.1.0_linux_amd64.zip
+  version: 3.2.3
+  source: https://releases.hashicorp.com/terraform-provider-null/3.2.3/terraform-provider-null_3.2.3_linux_amd64.zip
+  provider: registry.opentofu.org/hashicorp/null
 service_definitions:
 - smtp.yml
 parameters: []

--- a/terraform/bind/outputs.tf
+++ b/terraform/bind/outputs.tf
@@ -1,5 +1,11 @@
 output "smtp_server" { value = format("email-smtp.%s.amazonaws.com", var.region) }
 output "smtp_user" { value = aws_iam_access_key.access_key.id }
-output "smtp_password" { value = aws_iam_access_key.access_key.ses_smtp_password_v4 }
-output "secret_access_key" { value = aws_iam_access_key.access_key.secret }
+output "smtp_password" {
+  value     = aws_iam_access_key.access_key.ses_smtp_password_v4
+  sensitive = true
+}
+output "secret_access_key" {
+  value     = aws_iam_access_key.access_key.secret
+  sensitive = true
+}
 output "notification_webhook" { value = local.subscribed_webhook }

--- a/terraform/bind/provider.tf
+++ b/terraform/bind/provider.tf
@@ -1,4 +1,3 @@
 provider "aws" {
-  version = "~> 3.0"
-  region  = var.region
+  region = var.region
 }

--- a/terraform/provision/Dockerfile
+++ b/terraform/provision/Dockerfile
@@ -1,7 +1,14 @@
-FROM hashicorp/terraform:0.13.7 as terraform
+FROM alpine:3.20 AS tofu
 
-RUN apk update
-RUN apk add --update git 
+ADD install-opentofu.sh /install-opentofu.sh
+RUN chmod +x /install-opentofu.sh
+RUN apk add gpg gpg-agent
+RUN ./install-opentofu.sh --install-method standalone --install-path / --symlink-path -
+
+FROM ubuntu:20.04
+
+COPY --from=tofu /tofu /usr/local/bin/tofu
+RUN apt-get update && apt-get install -y git
 
 ENTRYPOINT ["/bin/sh"]
 

--- a/terraform/provision/provider.tf
+++ b/terraform/provision/provider.tf
@@ -1,4 +1,3 @@
 provider "aws" {
-  version = "~> 3.0"
-  region  = var.region
+  region = var.region
 }

--- a/terraform/provision/versions.tf
+++ b/terraform/provision/versions.tf
@@ -1,11 +1,13 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 5.88"
     }
     null = {
-      source = "hashicorp/null"
+      source  = "hashicorp/null"
+      version = "~> 3.2"
     }
   }
-  required_version = ">= 0.13"
+  required_version = "~> 1.9"
 }


### PR DESCRIPTION
This updates the brokerpak to OpenTofu to match the latest versions of the Cloud Service Broker, and bumps all of the providers to recent versions.

It passes testing both running `tofu apply` in `terraform/provision/` and running `make up demo-up demo-down` in the  main directory.

After merging, we can tag this commit as v3.0.0 and then specify that new version in datagov-ssb.